### PR TITLE
Fix a bug where meta data was read from the content

### DIFF
--- a/src/Kurenai/DocumentParser.php
+++ b/src/Kurenai/DocumentParser.php
@@ -30,7 +30,7 @@ class DocumentParser
     public function parse($source)
     {
         $content = $this->parseContent($source);
-        $metadata = $this->parseMetadata($source);
+        $metadata = $this->parseMetadata($this->parseHeader($source));
         return $this->buildDocument($content, $metadata);
     }
 

--- a/tests/DocumentParserTest.php
+++ b/tests/DocumentParserTest.php
@@ -88,6 +88,16 @@ class DocumentParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar', 'baz' => 'bar:bar'), $s);
     }
 
+    public function testMetadataCantBeParsedFromContent()
+    {
+        $parser = new DocumentParser();
+        $file = file_get_contents(__DIR__.'/fixtures/document_04.md');
+        $document = $parser->parse($file);
+        $meta = $document->get();
+        $this->assertCount(2, $meta);
+        $this->assertSame(array('foo' => 'bar', 'baz' => 'boo'), $meta);
+    }
+
     public function testBuildDocumentCreatesDocumentCorrectly()
     {
         $d = new DocumentParser();

--- a/tests/fixtures/document_04.md
+++ b/tests/fixtures/document_04.md
@@ -1,0 +1,4 @@
+foo: bar
+baz: boo
+-------
+baz: boz


### PR DESCRIPTION
Meta data was being read from the content causing my main meta data to be invalid. 

For example.

```
foo: bar
baz: boo
-------
baz: boz
```

`baz: boz` would overwrite `baz: boo`. This PR fixes this problem so meta data can only be read from the header and not the content.
