### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $slug = $document->get('slug');
 
 Kurenai was intended for use with flat file publishing solutions.
 
-Kurenai is availabe on packagist as [daylerees/kurenai](https://packagist.org/packages/daylerees/kurenai).
+Kurenai is available on packagist as [daylerees/kurenai](https://packagist.org/packages/daylerees/kurenai).
 
 The package is copyright (c) 2013 Dayle Rees and released under the MIT License [<http://opensource.org/licenses/MIT>](http://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
daylerees, I've corrected a typographical error in the documentation of the [kurenai](https://github.com/daylerees/kurenai) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.